### PR TITLE
Packaging fixes

### DIFF
--- a/Config.mk.in
+++ b/Config.mk.in
@@ -32,8 +32,8 @@ CFLAGS		:= -Wall -Wextra -Wstrict-prototypes -Wpointer-arith \
 		   -Wcast-align -Wmissing-prototypes -Wwrite-strings \
 		   -Wcast-qual -std=c11 @CUSTOMINCDIR@
 LDFLAGS		:= @CUSTOMLIBDIR@
-CURSES_LIBS	:= @libncurses@
-MATH_LIBS	:= @libm@
+CURSES_LIBS	:= -lncurses
+MATH_LIBS	:= -lm
 ifdef DEBUG
     CFLAGS	+= -O0 -ggdb3
 else

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,11 @@ $O%.o:	%.c
 	@echo "    Compiling $< to assembly ..."
 	@${CC} ${CFLAGS} -S -o $@ -c $<
 
+${MANDIR}/man6/%.6.gz:
+	@echo "Installing $@ ..."
+	@${INSTALLDATA} $< ${@:.gz=}
+	@gzip -9 ${@:.gz=}
+
 ################ Installation ##########################################
 
 ifdef BINDIR

--- a/Makefile
+++ b/Makefile
@@ -5,25 +5,6 @@
 CONFS	:= Config.mk config.h
 ONAME   := $(notdir $(abspath $O))
 
-include common/Module.mk
-include adventure/Module.mk
-include atc/Module.mk
-include battlestar/Module.mk
-include caesar/Module.mk
-include cribbage/Module.mk
-include dab/Module.mk
-include drop4/Module.mk
-include fish/Module.mk
-include gomoku/Module.mk
-include hack/Module.mk
-include hangman/Module.mk
-include klondike/Module.mk
-include robots/Module.mk
-include sail/Module.mk
-include snake/Module.mk
-include worm/Module.mk
-include wump/Module.mk
-
 ################ Compilation ###########################################
 
 .PHONY: all clean distclean maintainer-clean install uninstall
@@ -78,3 +59,22 @@ ${CONFS}:	configure
 	else echo "Running configure ...";\
 	    ./configure;\
 	fi
+
+include common/Module.mk
+include adventure/Module.mk
+include atc/Module.mk
+include battlestar/Module.mk
+include caesar/Module.mk
+include cribbage/Module.mk
+include dab/Module.mk
+include drop4/Module.mk
+include fish/Module.mk
+include gomoku/Module.mk
+include hack/Module.mk
+include hangman/Module.mk
+include klondike/Module.mk
+include robots/Module.mk
+include sail/Module.mk
+include snake/Module.mk
+include worm/Module.mk
+include wump/Module.mk

--- a/adventure/Module.mk
+++ b/adventure/Module.mk
@@ -32,8 +32,6 @@ ${adventure/EXEI}:	${adventure/EXE}
 	@echo "Installing $@ ..."
 	@${INSTALLEXE} $< $@
 ${adventure/MANI}:	adventure/${adventure/NAME}.6
-	@echo "Installing $@ ..."
-	@gzip -9 -c $< > $@ && chmod 644 $@
 
 uninstall:		adventure/uninstall
 adventure/uninstall:

--- a/atc/Module.mk
+++ b/atc/Module.mk
@@ -33,8 +33,6 @@ ${atc/EXEI}:	${atc/EXE}
 	@echo "Installing $@ ..."
 	@${INSTALLEXE} $< $@
 ${atc/MANI}:	atc/${atc/NAME}.6
-	@echo "Installing $@ ..."
-	@gzip -9 -c $< > $@ && chmod 644 $@
 ${atc/SCOREI}:
 	@echo "Creating initial score file $@ ..."
 	@${INSTALLSCORE} /dev/null $@

--- a/battlestar/Module.mk
+++ b/battlestar/Module.mk
@@ -33,8 +33,6 @@ ${battlestar/EXEI}:	${battlestar/EXE}
 	@echo "Installing $@ ..."
 	@${INSTALLEXE} $< $@
 ${battlestar/MANI}:	battlestar/${battlestar/NAME}.6
-	@echo "Installing $@ ..."
-	@gzip -9 -c $< > $@ && chmod 644 $@
 ${battlestar/SCOREI}:
 	@echo "Creating initial score file $@ ..."
 	@${INSTALLSCORE} /dev/null $@

--- a/caesar/Module.mk
+++ b/caesar/Module.mk
@@ -36,8 +36,6 @@ ${caesar/EXE2I}:	${caesar/EXEI}
 	@echo "Installing $@ ..."
 	@(cd ${BINDIR}; rm -f rot13; ln ${caesar/NAME} rot13)
 ${caesar/MANI}:	caesar/${caesar/NAME}.6
-	@echo "Installing $@ ..."
-	@gzip -9 -c $< > $@ && chmod 644 $@
 
 uninstall:		caesar/uninstall
 caesar/uninstall:

--- a/configure
+++ b/configure
@@ -193,23 +193,6 @@ for i in $HEADERS; do
     done
 done
 
-LIBPATH="`echo $LD_LIBRARY_PATH | tr ':' ' '` $ac_var_libdir $ac_var_customlibdir /lib /usr/lib /usr/local/lib /usr/lib/x86_64-linux-gnu"
-LIBPATH=`echo $LIBPATH | sed 's/\\\\//g'`
-LIBSUFFIX="so a la dylib"
-for i in $LIBS; do
-    found=
-    for p in $LIBPATH; do
-	for s in $LIBSUFFIX; do
-	    if [ -r "$p/lib$i.$s" ]; then
-		found=" -l$i"
-		break
-	    fi
-	done
-	[ -z "$found" ] || break
-    done
-    sub "s/ @lib$i@/$found/g"
-done
-
 for i in $PROGS; do
     pname=`expr "$i" : '\([^=]*\)=[^=]*'`
     pcall=`expr "$i" : '[^=]*=\([^=]*\)'`

--- a/cribbage/Module.mk
+++ b/cribbage/Module.mk
@@ -32,8 +32,6 @@ ${cribbage/EXEI}:	${cribbage/EXE}
 	@echo "Installing $@ ..."
 	@${INSTALLEXE} $< $@
 ${cribbage/MANI}:	cribbage/${cribbage/NAME}.6
-	@echo "Installing $@ ..."
-	@gzip -9 -c $< > $@ && chmod 644 $@
 
 uninstall:		cribbage/uninstall
 cribbage/uninstall:

--- a/dab/Module.mk
+++ b/dab/Module.mk
@@ -32,8 +32,6 @@ ${dab/EXEI}:	${dab/EXE}
 	@echo "Installing $@ ..."
 	@${INSTALLEXE} $< $@
 ${dab/MANI}:	dab/${dab/NAME}.6
-	@echo "Installing $@ ..."
-	@gzip -9 -c $< > $@ && chmod 644 $@
 
 uninstall:		dab/uninstall
 dab/uninstall:

--- a/drop4/Module.mk
+++ b/drop4/Module.mk
@@ -33,8 +33,6 @@ ${drop4/EXEI}:	${drop4/EXE}
 	@echo "Installing $@ ..."
 	@${INSTALLEXE} $< $@
 ${drop4/MANI}:	drop4/${drop4/NAME}.6
-	@echo "Installing $@ ..."
-	@gzip -9 -c $< > $@ && chmod 644 $@
 ${drop4/SCOREI}:
 	@echo "Creating initial score file $@ ..."
 	@${INSTALLSCORE} /dev/null $@


### PR DESCRIPTION
Hi Mike!

I'm trying to package your repo for GuixSD, and ran into a couple of issues.
I fixed them, and hope you would consider them for inclusion.
If you think they break something for other users, please, let me know so I can rework them.

Here's the rationale:
Guix runs the build for each package in a separate chroot jail.
The usual directory structure is not there - no `/usr`, `/var`, etc.
All the dependencies of a package are inside the jail, only in non-standard locations.
Therefore, everything has to be explicitly specified - via ./configure options or environment variables.

There were two assumptions in the code that were not true inside the jail - an existing `/usr/share/man/man6` directory, and existing `$LD_LIBRARY_PATH` (which is for run-time use, not build-time).